### PR TITLE
Fix booking section apostrophe

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
 
   <section id="booking" class="booking">
     <h2>Book Your Date</h2>
-    <p>Fill out the form below and we’ll contact you within 24 hours.</p>
+    <p>Fill out the form below and we'll contact you within 24 hours.</p>
     <form action="https://formspree.io/f/xwkgyqzd" method="POST">
       <input type="text" name="name" placeholder="Your Name" required>
       <input type="email" name="email" placeholder="Your Email" required>


### PR DESCRIPTION
## Summary
- Replace curly apostrophe with straight apostrophe in booking section for consistent typography.

## Testing
- `curl -s http://localhost:8000/index.html | grep -n "contact you" -n`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896e3abd560832a8de6289611ab55bd