### PR TITLE
Add booking form validation test setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Yung N Valuable
+
+Static site including a booking form.
+
+## Testing
+
+Install dependencies and run the test suite with:
+
+```
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "ynv",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/tests/booking_form.test.js
+++ b/tests/booking_form.test.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+const path = require('path');
+
+test('form prevents submission when required fields are empty', () => {
+  const html = fs.readFileSync(path.resolve(__dirname, '../booking.html'), 'utf8');
+  document.body.innerHTML = html;
+  const form = document.querySelector('form');
+  const event = new Event('submit', { cancelable: true });
+  form.addEventListener('submit', (e) => {
+    if (!form.checkValidity()) {
+      e.preventDefault();
+    }
+  });
+  form.dispatchEvent(event);
+  expect(event.defaultPrevented).toBe(true);
+});


### PR DESCRIPTION
## Summary
- add Jest configuration
- add test ensuring empty booking form fields prevent submission
- document test command in README

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896e3dd5a90832a808b4756746523c2