### PR TITLE
Refocus site on wedding photography only

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,8 +100,8 @@
   </header>
 
   <section class="hero">
-    <h1>Capture Your Day. Tell Your Story.</h1>
-    <p>Luxury Wedding Photography & Cinematic Videography in DC & Maryland</p>
+    <h1>Capture Your Day with Timeless Photography</h1>
+    <p>Luxury wedding photography in DC & Maryland</p>
     <a href="#booking" class="btn">📅 Reserve Your Date</a>
   </section>
 
@@ -112,12 +112,12 @@
       <p>Elegant, timeless photography that captures every emotion and detail with style.</p>
     </div>
     <div class="service-item">
-      <h3>🎥 Wedding Videography</h3>
-      <p>Professionally edited films with audio, drone footage, and cinematic storytelling.</p>
+      <h3>📔 Wedding Albums</h3>
+      <p>Beautifully crafted albums to preserve your favorite moments.</p>
     </div>
     <div class="service-item">
-      <h3>💍 Engagement Sessions</h3>
-      <p>Casual or styled engagement shoots included in select packages.</p>
+      <h3>👰 Bridal Portrait Sessions</h3>
+      <p>Personalized portrait sessions highlighting your unique style.</p>
     </div>
   </section>
 
@@ -125,15 +125,15 @@
     <h2>Pricing Packages</h2>
     <div class="price-item">
       <h3>Essentials Package – $1,000</h3>
-      <p>Up to 4 hours of coverage, 150+ edited photos, 2-minute highlight video.</p>
+      <p>Up to 4 hours of coverage and 150+ edited photos.</p>
     </div>
     <div class="price-item">
       <h3>Classic Package – $1,750</h3>
-      <p>6 hours of coverage, 300+ edited photos, 4-minute highlight video, 1 photographer + 1 videographer.</p>
+      <p>6 hours of coverage, 300+ edited photos, and a custom photo album.</p>
     </div>
     <div class="price-item">
       <h3>Signature Package – $2,500</h3>
-      <p>Full day coverage, 500+ edited photos, 7-minute film, drone footage, engagement shoot included.</p>
+      <p>Full day coverage, 500+ edited photos, second photographer, and bridal portrait session.</p>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- Tailor hero messaging to highlight wedding photography.
- Replace videography and engagement services with photography offerings.
- Revise pricing packages for photography-only options.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897039ab2ec832a8b5212a56adb9595