### PR TITLE
Refine pricing to emphasize photography offerings

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,15 +124,15 @@
     <h2>Pricing Packages</h2>
     <div class="price-item">
       <h3>Essentials Package – $1,000</h3>
-      <p>Up to 4 hours of coverage, 150+ edited photos, 2-minute highlight video.</p>
+      <p>Up to 4 hours of coverage, 150+ edited photos, online gallery for easy sharing.</p>
     </div>
     <div class="price-item">
       <h3>Classic Package – $1,750</h3>
-      <p>6 hours of coverage, 300+ edited photos, 4-minute highlight video, 1 photographer + 1 videographer.</p>
+      <p>6 hours of coverage, 300+ edited photos, custom photo album.</p>
     </div>
     <div class="price-item">
       <h3>Signature Package – $2,500</h3>
-      <p>Full day coverage, 500+ edited photos, 7-minute film, drone footage, engagement shoot included.</p>
+      <p>Full day coverage, 500+ edited photos, heirloom album, bridal portrait session, engagement shoot included.</p>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- Remove video references from wedding packages
- Add photography-focused perks like online gallery, album, and bridal portrait session

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/ynv/booking.html')*

------
https://chatgpt.com/codex/tasks/task_e_68970ec7f814832aa67394c5e8821c51