### PR TITLE
Add Formspree endpoint to booking form

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Static site including a booking form.
 
+The booking form posts to a [Formspree](https://formspree.io/) endpoint, which should be
+configured in your Formspree account to handle submissions.
+
 ## Testing
 
 Install dependencies and run the test suite with:

--- a/booking.html
+++ b/booking.html
@@ -12,7 +12,7 @@
   </header>
 
   <section>
-    <form>
+    <form action="https://formspree.io/f/xwkgyqzd" method="POST">
       <label>Name:<br><input type="text" name="name" required></label><br><br>
       <label>Email:<br><input type="email" name="email" required></label><br><br>
       <label>Event Date:<br><input type="date" name="date" required></label><br><br>


### PR DESCRIPTION
## Summary
- wire booking form to Formspree endpoint for submission
- document Formspree setup in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897118d066c832a8f6b734a9f0e11eb