### PR TITLE
Add shared navigation snippet and include across pages

### DIFF
--- a/booking.html
+++ b/booking.html
@@ -9,6 +9,12 @@
 <body>
   <header>
     <h1>Book Your Wedding Consultation</h1>
+    <!-- Shared site navigation -->
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="booking.html">Booking</a>
+      <a href="contact.html">Contact</a>
+    </nav>
   </header>
 
   <section>

--- a/contact.html
+++ b/contact.html
@@ -10,6 +10,12 @@
   <header>
     <h1>Contact Yung N Valuable</h1>
     <p>We'd love to hear about your big day.</p>
+    <!-- Shared site navigation -->
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="booking.html">Booking</a>
+      <a href="contact.html">Contact</a>
+    </nav>
   </header>
 
   <section>

--- a/index.html
+++ b/index.html
@@ -91,10 +91,11 @@
 <body>
   <header>
     <h1>Yung N Valuable Weddings</h1>
+    <!-- Shared site navigation -->
     <nav>
-      <a href="#services">Services</a>
-      <a href="#pricing">Pricing</a>
-      <a href="#contact">Contact</a>
+      <a href="index.html">Home</a>
+      <a href="booking.html">Booking</a>
+      <a href="contact.html">Contact</a>
     </nav>
   </header>
 

--- a/nav.html
+++ b/nav.html
@@ -1,0 +1,6 @@
+<!-- Shared navigation snippet -->
+<nav>
+  <a href="index.html">Home</a>
+  <a href="booking.html">Booking</a>
+  <a href="contact.html">Contact</a>
+</nav>


### PR DESCRIPTION
## Summary
- add reusable `nav.html` snippet linking to home, booking, and contact pages
- embed new navigation block in the header of index, booking, and contact pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897118dd514832abb096f5858d807b4