### PR TITLE
Add meta descriptions to HTML pages

### DIFF
--- a/booking.html
+++ b/booking.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Book a consultation with Yung N Valuable to reserve professional wedding photography for your special day.">
   <title>Book a Consultation - Yung N Valuable Weddings</title>
   <link rel="stylesheet" href="style.css">
 </head>

--- a/contact.html
+++ b/contact.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Reach out to Yung N Valuable Weddings by email or phone, or send a message through our contact form.">
   <title>Contact - Yung N Valuable Weddings</title>
   <link rel="stylesheet" href="style.css">
 </head>

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Luxury wedding photography services, packages, and contact information for DC and Maryland couples.">
   <title>Yung N Valuable Weddings</title>
   <link rel="stylesheet" href="style.css">
 </head>


### PR DESCRIPTION
## Summary
- add page-specific meta descriptions to index, booking, and contact pages

## Testing
- `npm test`
- `python -m html.parser index.html booking.html contact.html`
- Attempted `npx htmlhint index.html booking.html contact.html` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_689714ed39a0832a8b970ac7dc78cd3b