### PR TITLE
Add responsive design with media queries

### DIFF
--- a/style.css
+++ b/style.css
@@ -41,6 +41,11 @@ nav a {
   color: var(--secondary);
   text-align: center;
   padding: 6rem 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
 }
 
 .hero h1 {
@@ -87,9 +92,92 @@ ul li {
   background-color: #f4f4f4;
 }
 
+.services, .pricing {
+  display: grid;
+  gap: 2rem;
+}
+
+.services h2, .pricing h2 {
+  grid-column: 1 / -1;
+}
+
+.contact {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+@media (min-width: 768px) {
+  .hero {
+    padding: 8rem 2rem;
+  }
+
+  .hero h1 {
+    font-size: 3.5rem;
+  }
+
+  .hero p {
+    font-size: 1.5rem;
+  }
+
+  .services, .pricing {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .contact {
+    flex-direction: row;
+    justify-content: center;
+    gap: 2rem;
+  }
+
+  .contact h2 {
+    width: 100%;
+  }
+
+  section {
+    padding: 5rem 3rem;
+  }
+
+  .btn {
+    padding: 1.25rem 2.5rem;
+    font-size: 1.1rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .hero {
+    padding: 10rem 2rem;
+  }
+
+  .hero h1 {
+    font-size: 4rem;
+  }
+
+  .hero p {
+    font-size: 1.75rem;
+  }
+
+  .services, .pricing {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  section {
+    padding: 6rem 4rem;
+  }
+
+  .btn {
+    padding: 1.5rem 3rem;
+    font-size: 1.25rem;
+  }
+
+  .contact {
+    gap: 3rem;
+  }
+}
+
 .service-item, .price-item {
-  margin: 2rem auto;
-  max-width: 700px;
+  margin: 0;
+  width: 100%;
   background: #fff;
   padding: 2rem;
   border-radius: 10px;


### PR DESCRIPTION
## Summary
- Implement flexbox/grid layouts for hero, services, pricing, and contact sections
- Add responsive media queries at 768px and 1024px breakpoints
- Tweak padding, font sizes, and buttons for better readability across devices

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897198a8de4832a918782cb5769ae12